### PR TITLE
task(issue-22): update limitador-operator to track release-v0.17.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "limitador-operator"]
 	path = limitador-operator
 	url = https://github.com/Kuadrant/limitador-operator
-	branch = main
+	branch = release-v0.17.1


### PR DESCRIPTION
Update the limitador-operator submodule configuration to track the release-v0.17.1 branch instead of main.

Part of the alignment effort.
Related: Kuadrant/sector#22