### PR TITLE
feat: enable FIPS compliance check in bundle build pipeline

### DIFF
--- a/Containerfile.limitador-operator
+++ b/Containerfile.limitador-operator
@@ -26,7 +26,7 @@ COPY limitador-operator/pkg/ pkg/
 COPY limitador-operator/LICENSE /licenses/LICENSE
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -a -ldflags "${LDFLAGS}$(date -u +'%Y-%m-%dT%H:%M:%SZ')" -o ${BINARY_NAME} main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux GOARCH=$(go env GOARCH) go build -a -tags strictfipsruntime -ldflags "${LDFLAGS}$(date -u +'%Y-%m-%dT%H:%M:%SZ')" -o ${BINARY_NAME} main.go
 
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest


### PR DESCRIPTION
## Summary

Add FIPS compliance check to the operator bundle build pipeline using the official Konflux `fips-operator-bundle-check-oci-ta` task.

## Changes

- `.tekton/bundle-build-pipeline.yaml` — adds `fips-operator-bundle-check-oci-ta` task after `build-image-index`, gated on `skip-checks: false`. Uses the official task bundle from `quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1`
- `.tekton/multi-arch-build-pipeline.yaml` — removes the previous inline `fips-check` task that used the git resolver and RHOAI-owned images

The task scans `relatedImages` from the operator bundle image using `check-payload` to verify FIPS compliance. It only runs on bundle images that declare `features.operators.openshift.io/fips-compliant: "true"` or require an OpenShift subscription.

## Test plan

- [ ] Konflux bundle PR build passes including the new `fips-operator-bundle-check-oci-ta` task
- [ ] `check-payload` reports a successful result for all related images