### PR TITLE
Split image pullspecs

### DIFF
--- a/.github/workflows/generate-bundle.yml
+++ b/.github/workflows/generate-bundle.yml
@@ -3,14 +3,14 @@ name: Generate Bundle
 on:
   pull_request:
     paths:
-      - 'image-pullspecs.yaml'
+      - 'bundle-generation/image-pullspecs/**'
       - 'bundle-generation/**'
       - 'limitador-operator/bundle/**'
     branches:
       - 'rhcl-*'
   push:
     paths:
-      - 'image-pullspecs.yaml'
+      - 'bundle-generation/image-pullspecs/**'
       - 'bundle-generation/**'
       - 'limitador-operator/bundle/**'
     branches:
@@ -51,14 +51,14 @@ jobs:
         if: steps.changes.outputs.changes == 'true' && github.event_name == 'pull_request'
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: Generate Bundles after change to image-pullspecs.yaml or limitador-operator.yaml
+          commit_message: Generate Bundles after change to image-pullspecs or limitador-operator.yaml
 
       - name: Create PR for bundle changes (for protected branches)
         if: steps.changes.outputs.changes == 'true' && github.event_name == 'push'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Generate Bundles after change to image-pullspecs.yaml or limitador-operator.yaml
+          commit-message: Generate Bundles after change to image-pullspecs or limitador-operator.yaml
           branch: bundle-changes-${{ github.ref_name }}
           delete-branch: true
           title: 'Auto-generated bundle updates for ${{ github.ref_name }}'
@@ -67,7 +67,7 @@ jobs:
             This PR was automatically created by the Generate Bundle workflow.
 
             ## Changes
-            - Regenerated bundles after changes to image-pullspecs.yaml or limitador-operator.yaml
+            - Regenerated bundles after changes to image-pullspecs or limitador-operator.yaml
 
             ## Base Branch
             `${{ github.ref_name }}`

--- a/bundle-generation/generate-bundle.sh
+++ b/bundle-generation/generate-bundle.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="${SCRIPT_DIR}/.."
 UPSTREAM_BUNDLE="${PROJECT_ROOT}/limitador-operator/bundle"
-IMAGE_PULLSPECS="${PROJECT_ROOT}/image-pullspecs.yaml"
+IMAGE_PULLSPECS_DIR="${SCRIPT_DIR}/image-pullspecs"
 LIMITADOR_CONFIG="${SCRIPT_DIR}/limitador-operator.yaml"
 ANNOTATIONS_FILE="${SCRIPT_DIR}/annotations.yaml"
 
@@ -28,20 +28,20 @@ if [[ ! -f "$LIMITADOR_CONFIG" ]]; then
     exit 1
 fi
 
-if [[ ! -f "$IMAGE_PULLSPECS" ]]; then
-    echo "Error: Image pullspecs not found at $IMAGE_PULLSPECS"
+if [[ ! -d "$IMAGE_PULLSPECS_DIR" ]]; then
+    echo "Error: Image pullspecs directory not found at $IMAGE_PULLSPECS_DIR"
     exit 1
 fi
 
 echo "========================================"
 echo "Loading configuration from:"
 echo "  Config:      $LIMITADOR_CONFIG"
-echo "  Pullspecs:   $IMAGE_PULLSPECS"
+echo "  Pullspecs:   $IMAGE_PULLSPECS_DIR"
 echo "========================================"
 
-# Read image pullspecs
-OPERATOR_IMAGE=$(yq '.images.operator' "$IMAGE_PULLSPECS")
-LIMITADOR_IMAGE=$(yq '.images.limitador' "$IMAGE_PULLSPECS")
+# Read image pullspecs from individual files
+OPERATOR_IMAGE=$(yq '.image' "${IMAGE_PULLSPECS_DIR}/limitador-operator.yaml")
+LIMITADOR_IMAGE=$(yq '.image' "${IMAGE_PULLSPECS_DIR}/limitador.yaml")
 
 echo ""
 echo "Image pullspecs:"

--- a/bundle-generation/image-pullspecs/limitador-operator.yaml
+++ b/bundle-generation/image-pullspecs/limitador-operator.yaml
@@ -1,0 +1,3 @@
+# Image pullspec for Limitador Operator bundle
+# This file is updated automatically by Konflux
+image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-3-limitador-operator@sha256:38990ad0bc3d1ac80a751be22e16326110affb76bd5ed934bc70e3b65848e595

--- a/bundle-generation/image-pullspecs/limitador.yaml
+++ b/bundle-generation/image-pullspecs/limitador.yaml
@@ -1,0 +1,3 @@
+# Image pullspec for Limitador Operator bundle
+# This file is updated automatically by Konflux
+image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-3-limitador@sha256:302b04993a5a77df09901e1eefbb0a22d3cd9ed10b6b41aa26f2598ba8e3cbde

--- a/bundle-generation/limitador-operator.yaml
+++ b/bundle-generation/limitador-operator.yaml
@@ -43,10 +43,10 @@ architectures:
   os.linux: supported
 
 # Registry mappings for each environment
-# SHAs are extracted from the dev images in image-pullspecs.yaml
+# SHAs are extracted from the dev images in bundle-generation/image-pullspecs/
 registries:
   dev:
-    # Uses images directly from image-pullspecs.yaml
+    # Uses images directly from bundle-generation/image-pullspecs/
     operator: null
     limitador: null
   stage:

--- a/image-pullspecs.yaml
+++ b/image-pullspecs.yaml
@@ -1,5 +1,0 @@
-# Image pullspecs for Limitador Operator bundle
-# This file is updated automatically by Konflux
-images:
-  operator: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-3-limitador-operator@sha256:38990ad0bc3d1ac80a751be22e16326110affb76bd5ed934bc70e3b65848e595
-  limitador: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-3-limitador@sha256:302b04993a5a77df09901e1eefbb0a22d3cd9ed10b6b41aa26f2598ba8e3cbde


### PR DESCRIPTION
Splits image pullspecs into per-image files under bundle-generation/image-pullspecs, matching the approach from authorino-operator-product-build PR #264.