### PR TITLE
Migrate Konflux/Tekton config to RHCL 1.5 stream

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -6,13 +6,13 @@ spec:
   imageDigestMirrors:
     - source: registry.redhat.io/rhcl-1/limitador-rhel9-operator
       mirrors:
-        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador-operator
+        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador-operator
     - source: registry.redhat.io/rhcl-1/limitador-rhel9
       mirrors:
-        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador
+        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador
     - source: registry.stage.redhat.io/rhcl-1/limitador-rhel9-operator
       mirrors:
-        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador-operator
+        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador-operator
     - source: registry.stage.redhat.io/rhcl-1/limitador-rhel9
       mirrors:
-        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador
+        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador

--- a/.tekton/rhcl-1-5-limitador-operator-bundle-dev-pull-request.yaml
+++ b/.tekton/rhcl-1-5-limitador-operator-bundle-dev-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.4" && ( "limitador-operator".pathChanged() || "Containerfile.limitador-operator".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/".pathChanged() || ".tekton/rhcl-1-4-limitador-operator-pull-request.yaml".pathChanged() || ".tekton/multi-arch-build-pipeline.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.5" && ( "bundle-dev/*".pathChanged() || "Containerfile.limitador-operator-bundle-dev".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-5-limitador-operator-bundle-dev-pull-request.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhcl-1-4-limitador-operator
-    appstudio.openshift.io/component: rhcl-1-4-limitador-operator
+    appstudio.openshift.io/application: rhcl-1-5-limitador-operator
+    appstudio.openshift.io/component: rhcl-1-5-limitador-operator-bundle-dev
     pipelines.appstudio.openshift.io/type: build
-  name: rhcl-1-4-limitador-operator-on-pull-request
+  name: rhcl-1-5-limitador-operator-bundle-dev-on-pull-request
   namespace: api-management-tenant
 spec:
   params:
@@ -23,17 +23,17 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador-operator:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador-operator-bundle-dev:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Containerfile.limitador-operator
+    value: Containerfile.limitador-operator-bundle-dev
   - name: prefetch-input
-    value: '[{"type": "rpm", "path": "."}, {"type": "gomod", "path": "./limitador-operator"}, {"type": "pip", "path": "."}]'
+    value: '[{"type": "rpm", "path": "."}]'
   pipelineRef:
-    name: build-pipeline
+    name: bundle-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhcl-1-4-limitador-operator
+    serviceAccountName: build-pipeline-rhcl-1-5-limitador-operator-bundle-dev
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhcl-1-5-limitador-operator-bundle-dev-push.yaml
+++ b/.tekton/rhcl-1-5-limitador-operator-bundle-dev-push.yaml
@@ -7,13 +7,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhcl-1.4" && ( "bundle-dev/*".pathChanged() || "Containerfile.limitador-operator-bundle-dev".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-4-limitador-operator-bundle-dev-push.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhcl-1.5" && ( "bundle-dev/*".pathChanged() || "Containerfile.limitador-operator-bundle-dev".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-5-limitador-operator-bundle-dev-push.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhcl-1-4-limitador-operator
-    appstudio.openshift.io/component: rhcl-1-4-limitador-operator-bundle-dev
+    appstudio.openshift.io/application: rhcl-1-5-limitador-operator
+    appstudio.openshift.io/component: rhcl-1-5-limitador-operator-bundle-dev
     pipelines.appstudio.openshift.io/type: build
-  name: rhcl-1-4-limitador-operator-bundle-dev-on-push
+  name: rhcl-1-5-limitador-operator-bundle-dev-on-push
   namespace: api-management-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador-operator-bundle-dev:{{revision}}
+    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador-operator-bundle-dev:{{revision}}
   - name: dockerfile
     value: Containerfile.limitador-operator-bundle-dev
   - name: prefetch-input
@@ -30,7 +30,7 @@ spec:
   pipelineRef:
     name: bundle-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhcl-1-4-limitador-operator-bundle-dev
+    serviceAccountName: build-pipeline-rhcl-1-5-limitador-operator-bundle-dev
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhcl-1-5-limitador-operator-bundle-pull-request.yaml
+++ b/.tekton/rhcl-1-5-limitador-operator-bundle-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.4" && ( "bundle/*".pathChanged() || "Containerfile.limitador-operator-bundle".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-4-limitador-operator-bundle-pull-request.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.5" && ( "bundle/*".pathChanged() || "Containerfile.limitador-operator-bundle".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-5-limitador-operator-bundle-pull-request.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhcl-1-4-limitador-operator
-    appstudio.openshift.io/component: rhcl-1-4-limitador-operator-bundle
+    appstudio.openshift.io/application: rhcl-1-5-limitador-operator
+    appstudio.openshift.io/component: rhcl-1-5-limitador-operator-bundle
     pipelines.appstudio.openshift.io/type: build
-  name: rhcl-1-4-limitador-operator-bundle-on-pull-request
+  name: rhcl-1-5-limitador-operator-bundle-on-pull-request
   namespace: api-management-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador-operator-bundle:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador-operator-bundle:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
@@ -33,7 +33,7 @@ spec:
   pipelineRef:
     name: bundle-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhcl-1-4-limitador-operator-bundle
+    serviceAccountName: build-pipeline-rhcl-1-5-limitador-operator-bundle
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhcl-1-5-limitador-operator-bundle-push.yaml
+++ b/.tekton/rhcl-1-5-limitador-operator-bundle-push.yaml
@@ -7,13 +7,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhcl-1.4" && ( "bundle/*".pathChanged() || "Containerfile.limitador-operator-bundle".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-4-limitador-operator-bundle-push.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhcl-1.5" && ( "bundle/*".pathChanged() || "Containerfile.limitador-operator-bundle".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-5-limitador-operator-bundle-push.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhcl-1-4-limitador-operator
-    appstudio.openshift.io/component: rhcl-1-4-limitador-operator-bundle
+    appstudio.openshift.io/application: rhcl-1-5-limitador-operator
+    appstudio.openshift.io/component: rhcl-1-5-limitador-operator-bundle
     pipelines.appstudio.openshift.io/type: build
-  name: rhcl-1-4-limitador-operator-bundle-on-push
+  name: rhcl-1-5-limitador-operator-bundle-on-push
   namespace: api-management-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador-operator-bundle:{{revision}}
+    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador-operator-bundle:{{revision}}
   - name: dockerfile
     value: Containerfile.limitador-operator-bundle
   - name: prefetch-input
@@ -30,7 +30,7 @@ spec:
   pipelineRef:
     name: bundle-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhcl-1-4-limitador-operator-bundle
+    serviceAccountName: build-pipeline-rhcl-1-5-limitador-operator-bundle
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhcl-1-5-limitador-operator-bundle-stage-pull-request.yaml
+++ b/.tekton/rhcl-1-5-limitador-operator-bundle-stage-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.4" && ( "bundle-dev/*".pathChanged() || "Containerfile.limitador-operator-bundle-dev".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-4-limitador-operator-bundle-dev-pull-request.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.5" && ( "bundle-stage/*".pathChanged() || "Containerfile.limitador-operator-bundle-stage".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-5-limitador-operator-bundle-stage-pull-request.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhcl-1-4-limitador-operator
-    appstudio.openshift.io/component: rhcl-1-4-limitador-operator-bundle-dev
+    appstudio.openshift.io/application: rhcl-1-5-limitador-operator
+    appstudio.openshift.io/component: rhcl-1-5-limitador-operator-bundle-stage
     pipelines.appstudio.openshift.io/type: build
-  name: rhcl-1-4-limitador-operator-bundle-dev-on-pull-request
+  name: rhcl-1-5-limitador-operator-bundle-stage-on-pull-request
   namespace: api-management-tenant
 spec:
   params:
@@ -23,17 +23,17 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador-operator-bundle-dev:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador-operator-bundle-stage:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Containerfile.limitador-operator-bundle-dev
+    value: Containerfile.limitador-operator-bundle-stage
   - name: prefetch-input
     value: '[{"type": "rpm", "path": "."}]'
   pipelineRef:
     name: bundle-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhcl-1-4-limitador-operator-bundle-dev
+    serviceAccountName: build-pipeline-rhcl-1-5-limitador-operator-bundle-stage
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhcl-1-5-limitador-operator-bundle-stage-push.yaml
+++ b/.tekton/rhcl-1-5-limitador-operator-bundle-stage-push.yaml
@@ -7,13 +7,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhcl-1.4" && ( "bundle-stage/*".pathChanged() || "Containerfile.limitador-operator-bundle-stage".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-4-limitador-operator-bundle-stage-push.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhcl-1.5" && ( "bundle-stage/*".pathChanged() || "Containerfile.limitador-operator-bundle-stage".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-5-limitador-operator-bundle-stage-push.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhcl-1-4-limitador-operator
-    appstudio.openshift.io/component: rhcl-1-4-limitador-operator-bundle-stage
+    appstudio.openshift.io/application: rhcl-1-5-limitador-operator
+    appstudio.openshift.io/component: rhcl-1-5-limitador-operator-bundle-stage
     pipelines.appstudio.openshift.io/type: build
-  name: rhcl-1-4-limitador-operator-bundle-stage-on-push
+  name: rhcl-1-5-limitador-operator-bundle-stage-on-push
   namespace: api-management-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador-operator-bundle-stage:{{revision}}
+    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador-operator-bundle-stage:{{revision}}
   - name: dockerfile
     value: Containerfile.limitador-operator-bundle-stage
   - name: prefetch-input
@@ -30,7 +30,7 @@ spec:
   pipelineRef:
     name: bundle-build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhcl-1-4-limitador-operator-bundle-stage
+    serviceAccountName: build-pipeline-rhcl-1-5-limitador-operator-bundle-stage
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhcl-1-5-limitador-operator-pull-request.yaml
+++ b/.tekton/rhcl-1-5-limitador-operator-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.4" && ( "bundle-stage/*".pathChanged() || "Containerfile.limitador-operator-bundle-stage".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-4-limitador-operator-bundle-stage-pull-request.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.5" && ( "limitador-operator".pathChanged() || "Containerfile.limitador-operator".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/".pathChanged() || ".tekton/rhcl-1-5-limitador-operator-pull-request.yaml".pathChanged() || ".tekton/multi-arch-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhcl-1-4-limitador-operator
-    appstudio.openshift.io/component: rhcl-1-4-limitador-operator-bundle-stage
+    appstudio.openshift.io/application: rhcl-1-5-limitador-operator
+    appstudio.openshift.io/component: rhcl-1-5-limitador-operator
     pipelines.appstudio.openshift.io/type: build
-  name: rhcl-1-4-limitador-operator-bundle-stage-on-pull-request
+  name: rhcl-1-5-limitador-operator-on-pull-request
   namespace: api-management-tenant
 spec:
   params:
@@ -23,17 +23,17 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador-operator-bundle-stage:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador-operator:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Containerfile.limitador-operator-bundle-stage
+    value: Containerfile.limitador-operator
   - name: prefetch-input
-    value: '[{"type": "rpm", "path": "."}]'
+    value: '[{"type": "rpm", "path": "."}, {"type": "gomod", "path": "./limitador-operator"}, {"type": "pip", "path": "."}]'
   pipelineRef:
-    name: bundle-build-pipeline
+    name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhcl-1-4-limitador-operator-bundle-stage
+    serviceAccountName: build-pipeline-rhcl-1-5-limitador-operator
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhcl-1-5-limitador-operator-push.yaml
+++ b/.tekton/rhcl-1-5-limitador-operator-push.yaml
@@ -8,13 +8,13 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "rhcl-1.4" && ( "limitador-operator".pathChanged() || "Containerfile.limitador-operator".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/".pathChanged() || ".tekton/rhcl-1-4-limitador-operator-push.yaml".pathChanged() || ".tekton/multi-arch-build-pipeline.yaml".pathChanged() )
+      == "rhcl-1.5" && ( "limitador-operator".pathChanged() || "Containerfile.limitador-operator".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/".pathChanged() || ".tekton/rhcl-1-5-limitador-operator-push.yaml".pathChanged() || ".tekton/multi-arch-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhcl-1-4-limitador-operator
-    appstudio.openshift.io/component: rhcl-1-4-limitador-operator
+    appstudio.openshift.io/application: rhcl-1-5-limitador-operator
+    appstudio.openshift.io/component: rhcl-1-5-limitador-operator
     pipelines.appstudio.openshift.io/type: build
-  name: rhcl-1-4-limitador-operator-on-push
+  name: rhcl-1-5-limitador-operator-on-push
   namespace: api-management-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador-operator:{{revision}}
+    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador-operator:{{revision}}
   - name: dockerfile
     value: Containerfile.limitador-operator
   - name: prefetch-input
@@ -31,7 +31,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhcl-1-4-limitador-operator
+    serviceAccountName: build-pipeline-rhcl-1-5-limitador-operator
   workspaces:
   - name: git-auth
     secret:

--- a/Containerfile.limitador-operator-bundle
+++ b/Containerfile.limitador-operator-bundle
@@ -31,7 +31,7 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
-LABEL version="1.4.2" \
+LABEL version="1.5.0" \
       summary="Enables rate limiting for Gateways and applications in a Gateway API network" \
       name="rhcl-1/limitador-operator-bundle" \
       cpe="cpe:/a:redhat:connectivity_link:1::el9" \
@@ -42,7 +42,7 @@ LABEL version="1.4.2" \
       io.openshift.tags="api" \
       url="" \
       distribution-scope="public" \
-      release="1.4.2" \
+      release="1.5.0" \
       url="" \
       com.redhat.component="Red Hat Connectivity Link Operator Bundle" \
       vendor="Red Hat, Inc."

--- a/Containerfile.limitador-operator-bundle-dev
+++ b/Containerfile.limitador-operator-bundle-dev
@@ -31,7 +31,7 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
-LABEL version="1.4.2" \
+LABEL version="1.5.0" \
       summary="Enables rate limiting for Gateways and applications in a Gateway API network" \
       name="rhcl-1/limitador-operator-bundle" \
       cpe="cpe:/a:redhat:connectivity_link:1::el9" \
@@ -42,7 +42,7 @@ LABEL version="1.4.2" \
       io.openshift.tags="api" \
       url="" \
       distribution-scope="public" \
-      release="1.4.2" \
+      release="1.5.0" \
       url="" \
       com.redhat.component="Red Hat Connectivity Link Operator Bundle" \
       vendor="Red Hat, Inc."

--- a/Containerfile.limitador-operator-bundle-stage
+++ b/Containerfile.limitador-operator-bundle-stage
@@ -31,7 +31,7 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
-LABEL version="1.4.2" \
+LABEL version="1.5.0" \
       summary="Enables rate limiting for Gateways and applications in a Gateway API network" \
       name="rhcl-1/limitador-operator-bundle" \
       cpe="cpe:/a:redhat:connectivity_link:1::el9" \
@@ -42,7 +42,7 @@ LABEL version="1.4.2" \
       io.openshift.tags="api" \
       url="" \
       distribution-scope="public" \
-      release="1.4.2" \
+      release="1.5.0" \
       url="" \
       com.redhat.component="Red Hat Connectivity Link Operator Bundle" \
       vendor="Red Hat, Inc."

--- a/bundle-dev/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle-dev/manifests/limitador-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-  name: limitador-operator.v1.4.2
+  name: limitador-operator.v1.5.0
   namespace: placeholder
   labels:
     operatorframework.io/os.linux: supported
@@ -267,4 +267,4 @@ spec:
   relatedImages:
     - image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador@sha256:d09460477f9e76edf14828c6b0bc8b64066dcfbd505dd4f8b29412483767c686
       name: limitador
-  version: 1.4.2
+  version: 1.5.0

--- a/bundle-generation/limitador-operator.yaml
+++ b/bundle-generation/limitador-operator.yaml
@@ -4,8 +4,8 @@
 
 # CSV metadata
 csv:
-  name: limitador-operator.v1.4.2
-  version: "1.4.2"
+  name: limitador-operator.v1.5.0
+  version: "1.5.0"
   displayName: Limitador Operator
   description: "Enables rate limiting for Gateways and applications in a Gateway API network. Part of Red Hat Connectivity Link"
   icon:

--- a/bundle-stage/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle-stage/manifests/limitador-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-  name: limitador-operator.v1.4.2
+  name: limitador-operator.v1.5.0
   namespace: placeholder
   labels:
     operatorframework.io/os.linux: supported
@@ -267,4 +267,4 @@ spec:
   relatedImages:
     - image: registry.stage.redhat.io/rhcl-1/limitador-rhel9@sha256:d09460477f9e76edf14828c6b0bc8b64066dcfbd505dd4f8b29412483767c686
       name: limitador
-  version: 1.4.2
+  version: 1.5.0

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-  name: limitador-operator.v1.4.2
+  name: limitador-operator.v1.5.0
   namespace: placeholder
   labels:
     operatorframework.io/os.linux: supported
@@ -267,4 +267,4 @@ spec:
   relatedImages:
     - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:d09460477f9e76edf14828c6b0bc8b64066dcfbd505dd4f8b29412483767c686
       name: limitador
-  version: 1.4.2
+  version: 1.5.0


### PR DESCRIPTION
Migrates the limitador-operator downstream build config from the 1.4 stream to 1.5.

## Changes
- **Rename Tekton pipeline files** (`rhcl-1-4-*` → `rhcl-1-5-*`) and update internal references: `target_branch == "rhcl-1.5"`, application/component labels, output-image pullspecs, service accounts, and self-referencing `pathChanged()` paths.
- **Update `images-mirror-set.yaml`** component mirrors to the `rhcl-1-5` stream.
- **Bump bundle version** `1.4.2` → `1.5.0` in `bundle-generation/limitador-operator.yaml` and Containerfile labels, and regenerate the dev/stage/prod bundle CSVs (`make bundle`, version-only diff).

Shared pipeline files are version-agnostic and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)